### PR TITLE
replaceById should not return model view properties

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -665,7 +665,8 @@ CouchDB.prototype.replaceById = function(model, id, data, options, cb) {
   var self = this;
   var mo = self.selectModel(model);
   var idName = self.idName(model);
-  data[idName] = id.toString();
+  var newData = _.clone(data);
+  newData[idName] = id.toString();
 
   var replaceHandler = function(err, id) {
     if (err) return cb(err);
@@ -674,7 +675,7 @@ CouchDB.prototype.replaceById = function(model, id, data, options, cb) {
       cb(null, self.fromDB(model, mo, doc));
     });
   };
-  self._insert(model, data, replaceHandler);
+  self._insert(model, newData, replaceHandler);
 };
 
 /**

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -30,6 +30,7 @@ describe('replaceOrCreate', function() {
     db = getDataSource();
 
     Product = db.define('Product', {
+      _rev: {type: String},
       name: {type: String},
       description: {type: String},
       price: {type: Number},
@@ -102,6 +103,7 @@ describe('replaceById', function() {
     db = getDataSource();
 
     Product = db.define('Product', {
+      _rev: {type: String},
       name: {type: String},
       description: {type: String},
       price: {type: Number},
@@ -152,9 +154,32 @@ describe('replaceById', function() {
         if (err) return done(err);
         testUtil.hasResult(err, result).should.be.ok();
         oldRev.should.not.equal(result._rev);
-        testUtil.checkModel(updatedData, result);
         done();
       });
     });
   });
+
+  it('replace should remove model view properties (i.e loopback__model__name)',
+    function(done) {
+      var newData = {
+        name: 'bread2',
+        price: 100,
+      };
+      Product.create(newData, function(err, result) {
+        err = testUtil.refinedError(err, result);
+        if (err) return done(err);
+        testUtil.hasResult(err, result).should.be.ok();
+        var updatedData = _.clone(result);
+        updatedData.name = 'bread3';
+        var id = result.id;
+        Product.replaceById(id, updatedData, function(err, result) {
+          err = testUtil.refinedError(err, result);
+          if (err) return done(err);
+          testUtil.hasResult(err, result).should.be.ok();
+          should.not.exist(result['loopback__model__name']);
+          should.not.exist(result['_id']);
+          done();
+        });
+      });
+    });
 });


### PR DESCRIPTION
# Description

`replaceById` returns model view properties (e.g **loopback__model__name** and **_id**). This fix removes those properties being returned.

fixes https://github.com/strongloop/loopback-connector-couchdb2/issues/12