### PR TITLE
Add test folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "loopback-connector-couchdb2",
   "version": "0.9.0",
+  "publishConfig": {
+    "export-tests": true
+  },
   "description": "LoopBack Connector for CouchDB 2.0",
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Add test folder in the released pkg, so cloudant can import tests.
This flag is defined in [strong-tools](https://github.com/strongloop/strong-tools/blob/e8ad71673bcdb850182a4e78a60eb8e2b7d61dc1/bin/slt-release.sh#L206) and also used in juggler's package.json
(that's how we are able to import tests from juggler)