### PR TITLE
Make getDriver extendable

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -103,6 +103,14 @@ CouchDB.prototype.connect = function(cb) {
 };
 
 /**
+ * Return the driver instance, so cloudant can override this function,
+ * and call driver functions as `this.getDriverInst().foo`
+ */
+CouchDB.prototype.getDriverInst = function() {
+  return this.couchdb;
+};
+
+/**
  * Prepare the data for the save/insert DB operation
  *
  * @param {String} modelName The model name
@@ -611,7 +619,7 @@ CouchDB.prototype.bulkReplace = function(model, dataList, cb) {
  */
 CouchDB.prototype.ping = function(cb) {
   debug('CouchDB.prototype.ping');
-  this.couchdb.db.list(function(err, result) {
+  this.getDriverInst().db.list(function(err, result) {
     debug('CouchDB.prototype.ping results %j %j', err, result);
     if (err) cb('ping failed');
     else cb();
@@ -727,7 +735,7 @@ CouchDB.prototype.selectModel = function(model, migrate) {
   debug('CouchDB.prototype.selectModel use %j', dbName);
   this.pool[model] = {
     mo: mo,
-    db: this.couchdb.use(dbName),
+    db: self.getDriverInst().use(dbName),
     idName: idName,
     modelView: modelView,
     modelSelector: modelSelector,
@@ -1159,7 +1167,7 @@ CouchDB.prototype._find = function(dbName, query, cb) {
     body: query,
   };
 
-  self.couchdb.request(requestObject, cb);
+  self.getDriverInst().request(requestObject, cb);
 };
 
 /**

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -222,7 +222,7 @@ function mixinMigrate(CouchDB) {
       body: indexBody,
     };
 
-    self.couchdb.request(requestObject, cb);
+    self.getDriverInst().request(requestObject, cb);
   };
 
   /**
@@ -478,7 +478,7 @@ function mixinMigrate(CouchDB) {
       method: 'get',
     };
 
-    self.couchdb.request(requestObject, cb);
+    self.getDriverInst().request(requestObject, cb);
   };
 
   /**


### PR DESCRIPTION
### Description

Some places calls driver function `this.couchdb.foo`, which results in they are not extendable by Cloudant, so I abstract it to a function `CouchDB.prototype.getDriverInst`, then Cloudant can just override this function to get Cloudant driver instance, which is `this.cloudant`

Related PR https://github.com/strongloop/loopback-connector-cloudant/pull/163