### PR TITLE
Change nano to cloudant-nano

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -7,7 +7,7 @@
 
 var g = require('strong-globalize')();
 var Connector = require('loopback-connector').Connector;
-var Driver = require('nano');
+var Driver = require('cloudant-nano');
 var assert = require('assert');
 var debug = require('debug')('loopback:connector:couchdb2');
 var async = require('async');
@@ -1201,7 +1201,7 @@ CouchDB.prototype.defaultModelView = function() {
   return DEFAULT_MODEL_VIEW;
 };
 
-/** 
+/**
  * A model index's naming convention: '_design/LBModel__Foo__LBIndex__foo_index',
  * this function returns the property prefix, default as 'LBIndex'.
  * Default as 'LBIndex'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "^2.2.0",
     "lodash": "^4.17.4",
     "loopback-connector": "^4.0.0",
-    "nano": "^6.3.0",
+    "cloudant-nano": "^6.5.0",
     "request": "^2.81.0",
     "strong-globalize": "^2.6.6"
   },


### PR DESCRIPTION
### Description
Change Nano for `cloudant-nano` to prevent some security vulnerability in packages such as an outaded versions of `request` and `hawk` that are being used by the current `follow` versions. 


#### Related issues

connect to https://github.com/strongloop-internal/scrum-apex/issues/314

### Checklist


- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
