### PR TITLE
Add global limit

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -370,7 +370,7 @@ CouchDB.prototype.buildSort = function(mo, model, order) {
  * make it a private function, maybe need it somewhere
  */
 CouchDB.prototype._destroy = function _destroy(model, id, rev, options, cb) {
-  debug('CouchDB.prototype.destroy %j %j %j', model, id, rev, options);
+  debug('CouchDB.prototype._destroy %j %j %j', model, id, rev, options);
   var self = this;
   var mo = self.selectModel(model);
   id = id.toString();
@@ -421,7 +421,7 @@ CouchDB.prototype.destroyAll = function destroyAll(model, where, options, cb) {
   var dels = 0;
   var mo = self.selectModel(model);
 
-  self.all(model, {where: where}, {raw: true}, function(err, docs) {
+  self.all(model, {where: where, limit: self.getLimit()}, {raw: true}, function(err, docs) {
     if (err) return cb(err, null);
     async.each(docs, function(doc, cb2) {
       mo.db.destroy(doc._id, doc._rev, function(err, result) {
@@ -446,7 +446,7 @@ CouchDB.prototype.destroyAll = function destroyAll(model, where, options, cb) {
 CouchDB.prototype.count = function count(model, where, options, cb) {
   debug('CouchDB.prototype.count %j %j %j', model, where, options);
   var self = this;
-  self.all(model, {where: where}, {}, function(err, docs) {
+  self.all(model, {where: where, limit: self.getLimit()}, {}, function(err, docs) {
     cb(err, (docs && docs.length));
   });
 };
@@ -1210,6 +1210,13 @@ CouchDB.prototype.getIndexPropertyPrefix = function(mo) {
   return DEFAULT_PROPERTY_PREFIX;
 };
 
+CouchDB.prototype.getLimit = function(limit) {
+  return limit || this.getGlobalLimit();
+};
+
+CouchDB.prototype.getGlobalLimit = function() {
+  return this.settings.globalLimit;
+};
 // mixins
 // require('./discovery')(CouchDB);
 require('./view')(CouchDB);

--- a/test/count.test.js
+++ b/test/count.test.js
@@ -5,8 +5,9 @@
 
 'use strict';
 
-var _ = require('lodash');
-var should = require('should');
+const _ = require('lodash');
+const should = require('should');
+const COUNT_OF_SAMPLES = 70;
 var db, TestCountUser;
 
 if (!process.env.COUCHDB2_TEST_SKIP_INIT) {
@@ -15,7 +16,7 @@ if (!process.env.COUCHDB2_TEST_SKIP_INIT) {
 
 function create50Samples() {
   var r = [];
-  for (var i = 0; i < 70; i++) {
+  for (var i = 0; i < COUNT_OF_SAMPLES; i++) {
     r.push({name: 'user'.concat(i)});
   }
   return r;
@@ -27,6 +28,7 @@ function cleanUpData(done) {
 
 describe('count', function() {
   before((done) => {
+    // globalLimit is greater than COUNT_OF_SAMPLES
     const config = _.assign(global.config, {globalLimit: 100});
     const samples = create50Samples();
     db = global.getDataSource(config);
@@ -44,7 +46,7 @@ describe('count', function() {
   it('returns more than 25 results with global limit set', (done) => {
     TestCountUser.count((err, r)=> {
       if (err) return done(err);
-      console.log(r);
+      r.should.equal(COUNT_OF_SAMPLES);
       done();
     });
   });

--- a/test/count.test.js
+++ b/test/count.test.js
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-connector-couchdb2
+// This file is licensed under the Apache License 2.0.
+// License text available at https://opensource.org/licenses/Apache-2.0
+
+'use strict';
+
+var _ = require('lodash');
+var async = require('async');
+var should = require('should');
+var testUtil = require('./lib/test-util');
+var url = require('url');
+var db, TestCountUser;
+
+if (!process.env.COUCHDB2_TEST_SKIP_INIT) {
+  require('./init.js');
+}
+
+function create50Samples() {
+  var r = [];
+  for (var i = 0; i < 70; i++) {
+    r.push({name: 'user'.concat(i)});
+  }
+  return r;
+};
+
+function cleanUpData(done) {
+  TestCountUser.destroyAll(done);
+};
+
+describe('count', function() {
+  before(function(done) {
+    const config = _.assign(global.config, {globalLimit: 100});
+    const samples = create50Samples();
+    db = global.getDataSource(config);
+
+    TestCountUser = db.define('TestCountUser', {
+      name: {type: String},
+    }, {forceId: false});
+
+    db.automigrate((err) => {
+      if (err) return done(err);
+      TestCountUser.create(samples, done);
+    });
+  });
+
+  it('returns more than 25 results with global limit set', function(done) {
+    TestCountUser.count((err, r)=> {
+      if (err) return done(err);
+      console.log(r);
+      done();
+    });
+  });
+
+  it('destroys more than 25 results with global limit set', function(done) {
+    cleanUpData((err)=> {
+      if (err) return done(err);
+      TestCountUser.count((err, r) => {
+        if (err) return done(err);
+        r.should.equal(0);
+        done();
+      });
+    });
+  });
+});

--- a/test/count.test.js
+++ b/test/count.test.js
@@ -6,10 +6,7 @@
 'use strict';
 
 var _ = require('lodash');
-var async = require('async');
 var should = require('should');
-var testUtil = require('./lib/test-util');
-var url = require('url');
 var db, TestCountUser;
 
 if (!process.env.COUCHDB2_TEST_SKIP_INIT) {
@@ -29,7 +26,7 @@ function cleanUpData(done) {
 };
 
 describe('count', function() {
-  before(function(done) {
+  before((done) => {
     const config = _.assign(global.config, {globalLimit: 100});
     const samples = create50Samples();
     db = global.getDataSource(config);
@@ -44,7 +41,7 @@ describe('count', function() {
     });
   });
 
-  it('returns more than 25 results with global limit set', function(done) {
+  it('returns more than 25 results with global limit set', (done) => {
     TestCountUser.count((err, r)=> {
       if (err) return done(err);
       console.log(r);
@@ -52,7 +49,7 @@ describe('count', function() {
     });
   });
 
-  it('destroys more than 25 results with global limit set', function(done) {
+  it('destroys more than 25 results with global limit set', (done) => {
     cleanUpData((err)=> {
       if (err) return done(err);
       TestCountUser.count((err, r) => {


### PR DESCRIPTION
### Description
Specify a config variable `globalLimit` in your datasource file:

```
myCloudantDs: {
  url: <a_url>,
  database: <a_database>,
  globalLimit: 100
}
```

It will override the default limit(which is 25) in cloudant database. 

Please note:
The query level imit in function `Foo.find({limit: <a_query_level_limit>})`, should override the `globalLimit`, which is not implemented in this quick fix PR.

The precedence is:

- `count`, `destroyAll`: globalLimit > cloudant default limit value 25
- `find`: query level limit > globalLimit > cloudant default limit value 25

### Related issues

**This is a quick PR to fix https://github.com/strongloop/loopback-connector-couchdb2/issues/41
Please double check this feature and enable the globalLimit in other related methods in https://github.com/strongloop/loopback-connector-couchdb2/issues/39**


### Checklist



- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
