### PR TITLE
PCRE Regular Expressions

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -942,8 +942,8 @@ CouchDB.prototype._selectOperator = function(op, cond, regex) {
       containsRegex = true;
       break;
     case 'nlike':
-      var negitive = true;
-      newQuery = {$regex: this._regexToPCRE(cond, negitive)};
+      var negative = true;
+      newQuery = {$regex: this._regexToPCRE(cond, negative)};
       containsRegex = true;
       break;
     case 'regexp':
@@ -970,14 +970,14 @@ CouchDB.prototype._selectOperator = function(op, cond, regex) {
  *
  * @param {String|RegExp} regex Suspected regular expression
  */
-CouchDB.prototype._regexToPCRE = function(regex, negitive) {
+CouchDB.prototype._regexToPCRE = function(regex, negative) {
   if (typeof regex === 'string' || !(regex instanceof RegExp))
-    return negitive ? '[^' + regex + ']' : regex;
+    return negative ? '[^' + regex + ']' : regex;
 
   var flags = regex.flags ? '(?' + regex.flags + ')' : '';
   var source = regex.source;
 
-  if (negitive) return flags + '[^' + source + ']';
+  if (negative) return flags + '[^' + source + ']';
   return flags + source;
 };
 

--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -970,13 +970,13 @@ CouchDB.prototype._selectOperator = function(op, cond, regex) {
  *
  * @param {String|RegExp} regex Suspected regular expression
  */
-CouchDB.prototype._regexToPCRE = function (regex, negitive) {
-  if (typeof regex === 'string' || !(regex instanceof RegExp)) 
+CouchDB.prototype._regexToPCRE = function(regex, negitive) {
+  if (typeof regex === 'string' || !(regex instanceof RegExp))
     return negitive ? '[^' + regex + ']' : regex;
 
   var flags = regex.flags ? '(?' + regex.flags + ')' : '';
   var source = regex.source;
-  
+
   if (negitive) return flags + '[^' + source + ']';
   return flags + source;
 };

--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -938,11 +938,12 @@ CouchDB.prototype._selectOperator = function(op, cond, regex) {
       newQuery = {$ne: cond};
       break;
     case 'like':
-      newQuery = {$regex: cond};
+      newQuery = {$regex: this._regexToPCRE(cond)};
       containsRegex = true;
       break;
     case 'nlike':
-      newQuery = {$regex: '[^' + cond + ']'};
+      var negitive = true;
+      newQuery = {$regex: this._regexToPCRE(cond, negitive)};
       containsRegex = true;
       break;
     case 'regexp':
@@ -963,6 +964,21 @@ CouchDB.prototype._selectOperator = function(op, cond, regex) {
       newQuery['$' + op] = cond;
   }
   return [newQuery, containsRegex];
+};
+
+/** Build a PCRE compatiable regular expression from a javascript regular expression
+ *
+ * @param {String|RegExp} regex Suspected regular expression
+ */
+CouchDB.prototype._regexToPCRE = function (regex, negitive) {
+  if (typeof regex === 'string' || !(regex instanceof RegExp)) 
+    return negitive ? '[^' + regex + ']' : regex;
+
+  var flags = regex.flags ? '(?' + regex.flags + ')' : '';
+  var source = regex.source;
+  
+  if (negitive) return flags + '[^' + source + ']';
+  return flags + source;
 };
 
 /** Build an array of filter

--- a/test/regexp.test.js
+++ b/test/regexp.test.js
@@ -74,6 +74,24 @@ describe('CouchDB2 regexp', function() {
     });
   });
 
+  it('find all foos like b with javascript regex', function (done) {
+    var connector = db.connector;
+    Foo.find({where: {bar: {like: /B/i}}}, function (err, entries) {
+      if (err) return done(err);
+      entries.should.have.lengthOf(1);
+      entries[0].bar.should.equal('b');
+      done();
+    });
+  });
+
+  it('find all foos not like b with javascript regex', function (done) {
+    Foo.find({where: {bar: {nlike: /B/i}}}, function (err, entries) {
+      if (err) return done(err);
+      entries.should.have.lengthOf(N - 1);
+      done();
+    });
+  });
+
   after(function(done) {
     Foo.destroyAll(function() {
       done();

--- a/test/regexp.test.js
+++ b/test/regexp.test.js
@@ -75,7 +75,6 @@ describe('CouchDB2 regexp', function() {
   });
 
   it('find all foos like b with javascript regex', function(done) {
-    var connector = db.connector;
     Foo.find({where: {bar: {like: /B/i}}}, function(err, entries) {
       if (err) return done(err);
       entries.should.have.lengthOf(1);

--- a/test/regexp.test.js
+++ b/test/regexp.test.js
@@ -74,9 +74,9 @@ describe('CouchDB2 regexp', function() {
     });
   });
 
-  it('find all foos like b with javascript regex', function (done) {
+  it('find all foos like b with javascript regex', function(done) {
     var connector = db.connector;
-    Foo.find({where: {bar: {like: /B/i}}}, function (err, entries) {
+    Foo.find({where: {bar: {like: /B/i}}}, function(err, entries) {
       if (err) return done(err);
       entries.should.have.lengthOf(1);
       entries[0].bar.should.equal('b');
@@ -84,8 +84,8 @@ describe('CouchDB2 regexp', function() {
     });
   });
 
-  it('find all foos not like b with javascript regex', function (done) {
-    Foo.find({where: {bar: {nlike: /B/i}}}, function (err, entries) {
+  it('find all foos not like b with javascript regex', function(done) {
+    Foo.find({where: {bar: {nlike: /B/i}}}, function(err, entries) {
       if (err) return done(err);
       entries.should.have.lengthOf(N - 1);
       done();

--- a/test/regextopcre.test.js
+++ b/test/regextopcre.test.js
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback-connector-couchdb2
+// This file is licensed under the Apache License 2.0.
+// License text available at https://opensource.org/licenses/Apache-2.0
+
+// Comment test cases to get CI pass,
+// will recover them when CI config done
+
+'use strict';
+
+var should = require('should');
+var db;
+
+if (!process.env.COUCHDB2_TEST_SKIP_INIT) {
+  require('./init.js');
+}
+
+describe('CouchDB2 regexToPCRE', function() {
+  before(function(done) {
+    db = global.getSchema();
+    done();
+  });
+
+  it('return regular expression string', function () {
+    db.connector._regexToPCRE('b', false).should.equal('b');
+  });
+
+  it('return regular expression string as a negitive lookahead', function () {
+    db.connector._regexToPCRE('b', true).should.equal('[^b]');
+  });
+
+  it('return a pcre compliant regular expression', function () {
+    db.connector._regexToPCRE(/b/, false).should.equal('b');
+  });
+
+  it('return flags mapped to pcre syntax', function () {
+    db.connector._regexToPCRE(/b/im, false).should.equal('(?im)b');
+  });
+
+  it('return flags mapped to pcre syntax', function () {
+    db.connector._regexToPCRE(/b/i, false).should.equal('(?i)b');
+  });
+
+  it('return flags mapped to pcre syntax', function () {
+    db.connector._regexToPCRE(/b/i, true).should.equal('(?i)[^b]');
+  });
+});

--- a/test/regextopcre.test.js
+++ b/test/regextopcre.test.js
@@ -21,27 +21,27 @@ describe('CouchDB2 regexToPCRE', function() {
     done();
   });
 
-  it('return regular expression string', function () {
+  it('return regular expression string', function() {
     db.connector._regexToPCRE('b', false).should.equal('b');
   });
 
-  it('return regular expression string as a negitive lookahead', function () {
+  it('return regular expression string as a negitive lookahead', function() {
     db.connector._regexToPCRE('b', true).should.equal('[^b]');
   });
 
-  it('return a pcre compliant regular expression', function () {
+  it('return a pcre compliant regular expression', function() {
     db.connector._regexToPCRE(/b/, false).should.equal('b');
   });
 
-  it('return flags mapped to pcre syntax', function () {
+  it('return flags mapped to pcre syntax', function() {
     db.connector._regexToPCRE(/b/im, false).should.equal('(?im)b');
   });
 
-  it('return flags mapped to pcre syntax', function () {
+  it('return flags mapped to pcre syntax', function() {
     db.connector._regexToPCRE(/b/i, false).should.equal('(?i)b');
   });
 
-  it('return flags mapped to pcre syntax', function () {
+  it('return flags mapped to pcre syntax', function() {
     db.connector._regexToPCRE(/b/i, true).should.equal('(?i)[^b]');
   });
 });

--- a/test/regextopcre.test.js
+++ b/test/regextopcre.test.js
@@ -16,9 +16,8 @@ if (!process.env.COUCHDB2_TEST_SKIP_INIT) {
 }
 
 describe('CouchDB2 regexToPCRE', function() {
-  before(function(done) {
+  before(function() {
     db = global.getSchema();
-    done();
   });
 
   it('return regular expression string', function() {


### PR DESCRIPTION
### Description
Fixed issues with regular expressions on `like` and `nlike` queries. When a javascript RegExp is passed as a condition it will now be converted to a `PCRE` style regular expression.

#### Related issues
- connect to #51 
- connect to strongloop/loopback-connector-cloudant#189

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
