### PR TITLE
fix: honor fields in the filter

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -151,9 +151,10 @@ CouchDB.prototype.toDB = function(modelName, modelObject, doc) {
  * @param {String} modelName The model name
  * @param {Object} modelObject The model properties etc
  * @param {Object} doc The model document/data
+ * @param {Array} fields The fields to include in the result
  * @returns {Object} doc The model document/data
  */
-CouchDB.prototype.fromDB = function(modelName, modelObject, doc) {
+CouchDB.prototype.fromDB = function(modelName, modelObject, doc, fields) {
   var idName = this.idName(modelName);
   // we should return the `id` as an int if the user specified the property as an int
 
@@ -161,6 +162,11 @@ CouchDB.prototype.fromDB = function(modelName, modelObject, doc) {
     var idType = modelObject.mo.properties[idName].type.name;
   if (!doc) return doc;
   assert(doc._id);
+
+  if (fields && !fields.includes(idName)) {
+    delete doc._id;
+  }
+
   if (doc._id) {
     if (idType === 'Number')
       doc[idName] = parseInt(doc._id);
@@ -168,6 +174,7 @@ CouchDB.prototype.fromDB = function(modelName, modelObject, doc) {
       doc[idName] = doc._id;
     delete doc._id;
   }
+
   for (var i = 0; i < modelObject.dateFields.length; i++) {
     var dateField = modelObject.dateFields[i];
     var dateValue = doc[dateField];
@@ -301,7 +308,7 @@ CouchDB.prototype.all = function all(model, filter, options, cb) {
   include = function(docs, cb) {
     if (!options || !options.raw) {
       for (var i = 0; i < docs.length; i++) {
-        self.fromDB(model, mo, docs[i]);
+        self.fromDB(model, mo, docs[i], filter.fields);
       }
     }
     if (filter && filter.include) {
@@ -1087,7 +1094,8 @@ CouchDB.prototype._findRecursive = function(mo, query, docs, include, cb) {
         queryView);
       return cb(new Error(g.f(errMsg)));
     }
-    include(rst.docs, function() {
+    include(rst.docs, function(err) {
+      if (err) return cb(err);
       self._extendDocs(rst, docs, query, mo, include, cb);
     });
   });

--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -295,6 +295,7 @@ CouchDB.prototype.all = function all(model, filter, options, cb) {
   /* eslint-enable camelcase */
   if (filter.offset) query.skip = filter.offset;
   if (filter.limit) query.limit = filter.limit;
+  if (filter.fields) query.fields = filter.fields.concat('_id');
   if (filter.order) query.sort = self.buildSort(mo, model, filter.order);
   debug('CouchDB.prototype.all %j %j %j', model, filter, query);
   include = function(docs, cb) {


### PR DESCRIPTION
### Description

- Fixes the failure for [missing FK in the fields](https://github.com/strongloop/loopback-datasource-juggler/blob/97f631bd9cbb620d82ad2ac692628ce14f29061d/test/include.test.js#L49)

    - The `fields` filter was ignored and that's why the test above fails. This PR adds it to the query.
    - `fromDB` method will remove the id field is original filter doesn't have it in `fields`

- Fixes [catching the inclusion error](https://github.com/strongloop/loopback-datasource-juggler/blob/97f631bd9cbb620d82ad2ac692628ce14f29061d/test/include.test.js#L79)

    - `_findRecursive` invokes the `include` handler function without catching the error. That's why the test above returns null instead of throwing the expected error.
    - The fix exposed two new failures. They should have failed, while passed because the error was not propagated. The failure reason is the test case specifies `order` in filter but doesn't define index for the sortable field(which is required for couchdb2/cloudant connector).
     - The corresponding fix for ^ will be in juggler, we either make property `title` indexable for `Post` model, or skip that test for couchdb/cloudant connector. I will submit another PR.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] ~New tests added or existing tests modified to cover all changes~ The test cases are in juggler.
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
