### PR TITLE
fix: callback error when 404 returned

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -493,7 +493,6 @@ CouchDB.prototype.find =
     var self = this;
     var mo = self.selectModel(model);
     mo.db.get(id, function(err, doc) {
-      if (err && err.statusCode === 404) return cb(null, []);
       if (err) return cb(err);
       cb(null, self.fromDB(model, mo, doc));
     });


### PR DESCRIPTION
### Description

Pass the 404 error to callback for `findById`

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
