### PR TITLE
refactor: add options for search

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -317,7 +317,7 @@ CouchDB.prototype.all = function all(model, filter, options, cb) {
       cb();
     }
   };
-  self._findRecursive(mo, query, docs, include, function(err, result) {
+  self._findRecursive(mo, query, docs, include, options, function(err, result) {
     if (err) return cb(err, result);
     cb(null, result.docs);
   });
@@ -1073,7 +1073,7 @@ CouchDB.prototype._buildFilterArr = function(k, props) {
  * @param {Object} include Include filter
  * @callback {Function} cb The callback function
  */
-CouchDB.prototype._findRecursive = function(mo, query, docs, include, cb) {
+CouchDB.prototype._findRecursive = function(mo, query, docs, include, options, cb) {
   var self = this;
   mo.db.find(query, function(err, rst) {
     debug('CouchDB.prototype.all (findRecursive) results: %j %j', err, rst);
@@ -1096,7 +1096,7 @@ CouchDB.prototype._findRecursive = function(mo, query, docs, include, cb) {
     }
     include(rst.docs, function(err) {
       if (err) return cb(err);
-      self._extendDocs(rst, docs, query, mo, include, cb);
+      self._extendDocs(rst, docs, query, mo, include, options, cb);
     });
   });
 };
@@ -1108,7 +1108,7 @@ CouchDB.prototype._findRecursive = function(mo, query, docs, include, cb) {
  * @param {Object[]} docs Model document/data
  * @callback {Function} cb The callback function
  */
-CouchDB.prototype._extendDocs = function(rst, docs, query, mo, include, cb) {
+CouchDB.prototype._extendDocs = function(rst, docs, query, mo, include, options, cb) {
   var self = this;
   if (docs.length === 0 && rst.docs.length < 200) return cb(null, rst);
   for (var i = 0; i < rst.docs.length; i++) {
@@ -1120,7 +1120,7 @@ CouchDB.prototype._extendDocs = function(rst, docs, query, mo, include, cb) {
       cb(null, rst);
     } else {
       query.bookmark = rst.bookmark;
-      self._findRecursive(mo, query, docs, include, cb);
+      self._findRecursive(mo, query, docs, include, options, cb);
     }
   } else {
     cb(null, rst);


### PR DESCRIPTION
### Description

The prerequisite refactor PR for https://github.com/strongloop/loopback-connector-cloudant/pull/229, add `options` for private search functions.
connect to https://github.com/strongloop/loopback-connector-cloudant/pull/229

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
