### PR TITLE
feat: add partition field to model

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -720,7 +720,7 @@ CouchDB.prototype.replaceById = function(model, id, data, options, cb) {
  */
 CouchDB.prototype.selectModel = function(model, migrate) {
   var self = this;
-  var dbName, db, mo;
+  var dbName, db, mo, partitionKey;
   var modelView = null;
   var modelSelector = null;
   var dateFields = [];
@@ -747,20 +747,27 @@ CouchDB.prototype.selectModel = function(model, migrate) {
   }
 
   for (var p in mo.properties) {
-    if (mo.properties[p].type.name === 'Date') {
+    debug('visiting model property %s', p);
+    if (mo.properties[p].type && mo.properties[p].type.name === 'Date') {
       dateFields.push(p);
     }
+    if (mo.properties[p].isPartitionKey) {
+      partitionKey = p;
+      debug('partition key name %s', partitionKey);
+    }
   }
+
   var idName = this.idName(model);
   debug('CouchDB.prototype.selectModel use %j', dbName);
   this.pool[model] = {
-    mo: mo,
-    db: self.getDriverInst().use(dbName),
-    idName: idName,
-    modelView: modelView,
-    modelSelector: modelSelector,
     dateFields: dateFields,
+    db: self.getDriverInst().use(dbName),
     dbName: dbName,
+    idName: idName,
+    mo: mo,
+    modelSelector: modelSelector,
+    modelView: modelView,
+    partitionKey: partitionKey,
   };
 
   // nano doesn't have api 'find' while nodejs-cloudant has


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback-connector-cloudant/issues/217

- You can specify a partition key field in model definition like
```js
customers = db.define('customers', {
  userId: {type: Number, id: true},
  // partition key field
  countryCode: {type: String, isPartitionKey: true},
  name: String,
  zipCode: Number,
});
```

This PR adds the name of partition key field to couchdb/cloudant's model object. The corresponding cloudant PR is https://github.com/strongloop/loopback-connector-cloudant/pull/230

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-couchdb2) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
