### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .DS_Store
+.idea
+yarn.lock

--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -93,13 +93,26 @@ CouchDB.prototype.connect = function(cb) {
     }
   }
   self.couchdb = self.CouchDBDriver(self.options);
+
   if (self.options.database) {
     // check if database exists
-    self.couchdb.db.get(self.options.database, function(err) {
-      if (err) return cb(err);
+    self.couchdb.db.get(self.options.database, err => {
+      if (err) {
+        if (err.error === 'not_found') {
+          if (this.options.databaseCreate === 'true' || this.options.databaseCreate === '1') {
+            debug('Creating database', self.options.database);
+            self.couchdb.db.create(self.options.database, err => {
+              return cb(null, self.couchdb);
+            });
+            return;
+          }
+        }
+        return cb(err);
+      }
       return cb(err, self.couchdb);
     });
-  } else return cb(null, self.couchdb);
+  } else
+    return cb(null, self.couchdb);
 };
 
 /**

--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -102,6 +102,7 @@ CouchDB.prototype.connect = function(cb) {
           if (this.options.databaseCreate === 'true' || this.options.databaseCreate === '1') {
             debug('Creating database', self.options.database);
             self.couchdb.db.create(self.options.database, err => {
+              self.dataSource.emit('couchdb.connector.db_created');
               return cb(null, self.couchdb);
             });
             return;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "^3.1.0",
     "lodash": "^4.17.11",
     "loopback-connector": "^4.0.0",
-    "nano": "^6.4.2",
+    "nano": "^8.1.0",
     "request": "^2.81.0",
     "strong-globalize": "^4.1.2"
   },
@@ -50,7 +50,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strongloop/loopback-connector-couchdb2.git"
+    "url": "git://github.com/MeshekGal/loopback-connector-couchdb2.git"
   },
   "homepage": "https://github.com/strongloop/loopback-connector-couchdb2",
   "bugs": {

--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ var mochaBin = require.resolve('mocha/bin/_mocha');
 process.env.COUCHDB_DATABASE = 'test-db';
 process.env.COUCHDB_PASSWORD = 'pass';
 process.env.COUCHDB_USERNAME = 'admin';
-process.env.COUCHDB_DATABASE_CREATE = true;
+// process.env.COUCHDB_DATABASE_CREATE = true;
 
 // these are placeholders. They get set dynamically based on what IP and port
 // get assigned by docker.

--- a/test/couchdb.test.js
+++ b/test/couchdb.test.js
@@ -528,21 +528,36 @@ describe('CouchDB2 constructor', function() {
       done();
     });
   });
-  it('should give 404 error for nonexistant db', function(done) {
-    var myConfig = _.clone(global.config);
-    var parsedUrl = url.parse(myConfig.url);
-    parsedUrl.path = '';
-    myConfig.url = parsedUrl.format();
-    myConfig.database = 'idontexist';
-    var ds = global.getDataSource(myConfig);
-    ds.once('error', function(err) {
-      should.exist(err);
-      err.statusCode.should.equal(404);
-      err.error.should.equal('not_found');
-      err.reason.should.equal('Database does not exist.');
-      done();
+  if (global.config.databaseCreate === 'true' || global.config.databaseCreate === '1') {
+    it('should create nonexistant db on 404 error', function(done) {
+      var myConfig = _.clone(global.config);
+      var parsedUrl = url.parse(myConfig.url);
+      parsedUrl.path = '';
+      myConfig.url = parsedUrl.format();
+      myConfig.database = 'idontexist';
+      var ds = global.getDataSource(myConfig);
+      ds.once('created', function(err) {
+        should.equal(err, null);
+        done();
+      });
     });
-  });
+  } else {
+    it('should give 404 error for nonexistant db', function(done) {
+      var myConfig = _.clone(global.config);
+      var parsedUrl = url.parse(myConfig.url);
+      parsedUrl.path = '';
+      myConfig.url = parsedUrl.format();
+      myConfig.database = 'idontexist';
+      var ds = global.getDataSource(myConfig);
+      ds.once('error', function(err) {
+        should.exist(err);
+        err.statusCode.should.equal(404);
+        err.error.should.equal('not_found');
+        err.reason.should.equal('Database does not exist.');
+        done();
+      });
+    });
+  }
 });
 
 function seed() {

--- a/test/couchdb.test.js
+++ b/test/couchdb.test.js
@@ -536,7 +536,10 @@ describe('CouchDB2 constructor', function() {
       myConfig.url = parsedUrl.format();
       myConfig.database = 'idontexist';
       var ds = global.getDataSource(myConfig);
-      ds.once('created', function(err) {
+      /*
+        we should receive here 'create' event but juggler.DataSource has no such event - oops!
+       */
+      ds.once('couchdb.connector.db_created', function(err) {
         should.equal(err, null);
         done();
       });

--- a/test/init.js
+++ b/test/init.js
@@ -19,6 +19,7 @@ var config = {
   plugin: 'retry',
   retryAttempts: 10,
   retryTimeout: 50,
+  databaseCreate: process.env.COUCHDB_DATABASE_CREATE,
 };
 
 console.log('env config ', config);


### PR DESCRIPTION
1. Ported to nano 8
2. Patched to created database depending on config options with firing 'couchdb.connector.db_created' event through DataSource (which is not that kasher)

`COUCHDB_DATABASE_CREATE=1 MOCHA_OPT_GREP=404 yarn test`

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-couchdb2) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
