### PR TITLE
fix formatting on code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Given an array of data to be updated, Couchdb supports the idea of performing bu
 
 Example:
 
-```server/boot/script.js```
+*server/boot/script.js*
 
 ```javascript
 var dataToCreate = [


### PR DESCRIPTION
There is some formatting issue as shown below:

![Screen Shot 2020-08-05 at 10 28 30 PM](https://user-images.githubusercontent.com/25489897/89483832-072bb980-d76b-11ea-980e-270973fdffcf.png)

Following a similar pattern in [the view section](https://github.com/strongloop/loopback-connector-couchdb2/blob/master/README.md#view), I changed the file name reference to be italic. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-couchdb2) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
