### PR TITLE
feat: promisify findbyid

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -491,6 +491,7 @@ CouchDB.prototype.exists = function(model, id, options, cb) {
 CouchDB.prototype.find =
   CouchDB.prototype.findById = function(model, id, options, cb) {
     debug('CouchDB.prototype.find %j %j %j', model, id, options);
+    cb = cb || createPromiseCallback();
     const self = this;
     const mo = self.selectModel(model);
     mo.db.get(id, function(err, doc) {
@@ -498,6 +499,7 @@ CouchDB.prototype.find =
       if (err) return cb(err);
       cb(null, self.fromDB(model, mo, doc));
     });
+    return cb.promise;
   };
 
 /**
@@ -1251,6 +1253,18 @@ CouchDB.prototype.getLimit = function(limit) {
 CouchDB.prototype.getGlobalLimit = function() {
   return this.settings.globalLimit;
 };
+
+function createPromiseCallback() {
+  let cb;
+  const promise = new Promise(function(resolve, reject) {
+    cb = function(err, data) {
+      if (err) return reject(err);
+      return resolve(data);
+    };
+  });
+  cb.promise = promise;
+  return cb;
+}
 // mixins
 // require('./discovery')(CouchDB);
 require('./view')(CouchDB);

--- a/test/findById.test.js
+++ b/test/findById.test.js
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback-connector-couchdb2
+// This file is licensed under the Apache License 2.0.
+// License text available at https://opensource.org/licenses/Apache-2.0
+
+'use strict';
+
+const should = require('should');
+
+if (!process.env.COUCHDB2_TEST_SKIP_INIT) {
+  require('./init.js');
+}
+
+let db, newInstId, Todo, Item;
+
+describe('couchdb2 findById', function() {
+  before(function(done) {
+    db = global.getDataSource();
+
+    Todo = db.define('Todo', {
+      id: {type: String, id: true},
+      name: {type: String},
+    }, {forceId: false});
+
+    Item = db.define('Item', {
+      id: {type: String, id: true},
+      name: {type: String},
+    }, {forceId: false});
+
+    db.automigrate(function(err) {
+      should.not.exist(err);
+      done();
+    });
+  });
+
+  it('find an existing instance by id (Promise variant)', async function() {
+    const todo = await Todo.create({name: 'a todo'});
+    console.log(todo);
+    todo.name.should.eql('a todo');
+    newInstId = todo.id;
+    const result = await db.connector.findById('Todo', newInstId);
+    result.name.should.eql('a todo');
+    result.id.should.eql(todo.id);
+  });
+});


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

A follow up PR for https://github.com/strongloop/loopback-connector-cloudant/pull/241
See discussion from https://github.com/strongloop/loopback-connector-cloudant/pull/241#issuecomment-638860551
This PR:
 - promisifies the connector level findById so that lb4 app can call it using `await connector.findById()`
 - check if the found instance belong to the query model, if not throw error.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
