### PR TITLE
feat: reject when findById returns another model instance

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -497,6 +497,12 @@ CouchDB.prototype.find =
     mo.db.get(id, function(err, doc) {
       if (err && err.statusCode === 404) return cb(null, []);
       if (err) return cb(err);
+      // Check if the fetched record belong to the query model.
+      const modelView = mo.modelView;
+      if (doc[modelView] != model) {
+        debug(`Record with id ${id} does not belong to model ${model}.`);
+        return cb(null, []);
+      }
       cb(null, self.fromDB(model, mo, doc));
     });
     return cb.promise;

--- a/test/findById.test.js
+++ b/test/findById.test.js
@@ -35,11 +35,15 @@ describe('couchdb2 findById', function() {
 
   it('find an existing instance by id (Promise variant)', async function() {
     const todo = await Todo.create({name: 'a todo'});
-    console.log(todo);
     todo.name.should.eql('a todo');
     newInstId = todo.id;
     const result = await db.connector.findById('Todo', newInstId);
     result.name.should.eql('a todo');
     result.id.should.eql(todo.id);
+  });
+
+  it('returns empty when the found instance does not belong to query model', async function() {
+    const result = await db.connector.findById('Item', newInstId);
+    result.should.be.empty;
   });
 });


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

Follow up PR for https://github.com/strongloop/loopback-connector-couchdb2/pull/83
For method findById, reject if the found instance belong to another model.

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
